### PR TITLE
Prevent repeated RNG seeding in convolution examples

### DIFF
--- a/convolution_c.c
+++ b/convolution_c.c
@@ -71,9 +71,13 @@ void free_matrix(float** matrix, int rows) {
  */
 float** create_random_matrix(int rows, int cols, float min_val, float max_val) {
     float** matrix = allocate_matrix(rows, cols);
-    
-    // 初始化随机数生成器
-    srand((unsigned int)time(NULL));
+
+    // 初始化随机数生成器(只初始化一次，避免短时间内重复调用导致相同序列)
+    static int seeded = 0;
+    if (!seeded) {
+        srand((unsigned int)time(NULL));
+        seeded = 1;
+    }
     
     for (int i = 0; i < rows; i++) {
         for (int j = 0; j < cols; j++) {

--- a/convolution_cpp_parallel.cpp
+++ b/convolution_cpp_parallel.cpp
@@ -221,9 +221,13 @@ std::vector<std::vector<float>> detect_edges(const std::vector<std::vector<float
  */
 std::vector<std::vector<float>> generate_random_matrix(int rows, int cols, float min_val = 0.0f, float max_val = 1.0f) {
     std::vector<std::vector<float>> matrix(rows, std::vector<float>(cols));
-    
-    // 设置随机数生成器
-    srand(static_cast<unsigned int>(time(nullptr)));
+
+    // 设置随机数生成器(只初始化一次，避免快速重复调用产生相同序列)
+    static bool seeded = false;
+    if (!seeded) {
+        srand(static_cast<unsigned int>(time(nullptr)));
+        seeded = true;
+    }
     
     for (int i = 0; i < rows; ++i) {
         for (int j = 0; j < cols; ++j) {

--- a/convolution_cuda.cu
+++ b/convolution_cuda.cu
@@ -114,8 +114,12 @@ float* allocate_matrix_gpu(int rows, int cols) {
 
 // 创建随机矩阵
 void create_random_matrix(float* matrix, int rows, int cols, float min_val, float max_val) {
-    // 初始化随机数生成器
-    srand((unsigned int)time(NULL));
+    // 初始化随机数生成器(仅初始化一次，避免快速重复调用导致相同序列)
+    static int seeded = 0;
+    if (!seeded) {
+        srand((unsigned int)time(NULL));
+        seeded = 1;
+    }
     
     for (int i = 0; i < rows; i++) {
         for (int j = 0; j < cols; j++) {

--- a/convolution_cuda_advanced.cu
+++ b/convolution_cuda_advanced.cu
@@ -150,8 +150,12 @@ float* allocate_matrix_gpu(int rows, int cols) {
 
 // 创建随机矩阵
 void create_random_matrix(float* matrix, int rows, int cols, float min_val, float max_val) {
-    // 初始化随机数生成器
-    srand((unsigned int)time(NULL));
+    // 初始化随机数生成器(仅初始化一次，避免短时间内重复调用产生相同序列)
+    static int seeded = 0;
+    if (!seeded) {
+        srand((unsigned int)time(NULL));
+        seeded = 1;
+    }
     
     for (int i = 0; i < rows; i++) {
         for (int j = 0; j < cols; j++) {

--- a/convolution_cuda_pro.cu
+++ b/convolution_cuda_pro.cu
@@ -87,7 +87,11 @@ float* create_matrix(int rows, int cols) {
 }
 
 void rand_init(float* data, int size, float min_val=0.0f, float max_val=1.0f) {
-    srand(time(NULL));
+    static int seeded = 0;
+    if (!seeded) {
+        srand(time(NULL));
+        seeded = 1;
+    }
     for (int i = 0; i < size; ++i) {
         data[i] = min_val + (max_val - min_val) * (rand() / (float)RAND_MAX);
     }

--- a/convolution_hip_advanced.cu
+++ b/convolution_hip_advanced.cu
@@ -152,8 +152,12 @@ float* allocate_matrix_gpu(int rows, int cols) {
 
 // 创建随机矩阵
 void create_random_matrix(float* matrix, int rows, int cols, float min_val, float max_val) {
-    // 初始化随机数生成器
-    srand((unsigned int)time(NULL));
+    // 初始化随机数生成器(仅初始化一次，防止重复调用导致相同序列)
+    static int seeded = 0;
+    if (!seeded) {
+        srand((unsigned int)time(NULL));
+        seeded = 1;
+    }
     
     for (int i = 0; i < rows; i++) {
         for (int j = 0; j < cols; j++) {


### PR DESCRIPTION
## Summary
- Initialize random number generator only once in CPU, CUDA, and HIP convolution examples to avoid identical matrices on rapid consecutive calls.

## Testing
- `gcc convolution_c.c -lm -o convolution_c && ./convolution_c`
- `g++ -std=c++11 convolution_cpp_parallel.cpp -o convolution_cpp_parallel -pthread && ./convolution_cpp_parallel`
- `nvcc -arch=sm_50 convolution_cuda.cu -o convolution_cuda` *(fails: command not found)*
- `bash compile_hip.sh` *(fails: hipcc: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a81efe2de48321b21cea00828e6000